### PR TITLE
Fix missing video cleanup in gemini playground

### DIFF
--- a/frontend/components/gemini-playground.tsx
+++ b/frontend/components/gemini-playground.tsx
@@ -276,6 +276,20 @@ export default function GeminiVoiceChat() {
     setVideoEnabled(!videoEnabled);
   };
 
+  // Stop only the video stream and related timers
+  const stopVideo = () => {
+    if (videoStreamRef.current) {
+      videoStreamRef.current.getTracks().forEach(track => track.stop());
+      videoStreamRef.current = null;
+    }
+    if (videoIntervalRef.current) {
+      clearInterval(videoIntervalRef.current);
+      videoIntervalRef.current = null;
+    }
+    setVideoEnabled(false);
+    setVideoSource(null);
+  };
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- add missing `stopVideo` implementation in the frontend

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile standalone/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6864694d0438832bb0a3c80688918e4b